### PR TITLE
feat: Add GitHub Action to deploy PWA to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pwa.yml
+++ b/.github/workflows/deploy-pwa.yml
@@ -1,0 +1,43 @@
+name: Deploy PWA to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch
+    paths:
+      - 'my-pwa/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Specify a Node.js version, ensure it's compatible with your react-scripts
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./my-pwa
+
+      - name: Build PWA
+        run: npm run build
+        working-directory: ./my-pwa
+        env:
+          PUBLIC_URL: /pocket-reader # Explicitly set PUBLIC_URL for the build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./my-pwa/build
+          # Optional: if you want to deploy to a specific branch other than gh-pages
+          # publish_branch: gh-pages
+          # Optional: if you want to deploy to a specific directory on the branch
+          # destination_dir: pocket-reader # This is usually not needed if homepage is set correctly
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy PWA to GitHub Pages'

--- a/my-pwa/package.json
+++ b/my-pwa/package.json
@@ -2,6 +2,7 @@
   "name": "my-pwa",
   "version": "0.1.0",
   "private": true,
+  "homepage": "/pocket-reader/",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the deployment of the PWA located in the `my-pwa/` directory to GitHub Pages.

Key changes:
- Added `homepage: "/pocket-reader/"` to `my-pwa/package.json` to ensure the React application builds with the correct asset paths for hosting in a subdirectory.
- Created a new workflow file `.github/workflows/deploy-pwa.yml`:
  - Triggers on pushes to the `main` branch when changes occur in `my-pwa/`.
  - Checks out code, sets up Node.js.
  - Installs dependencies and builds the PWA from `my-pwa/`.
  - Deploys the contents of `my-pwa/build` to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.

The PWA will be served from the `/pocket-reader/` path on GitHub Pages. You will need to configure your repository settings for GitHub Pages to use the `gh-pages` branch as the source.