### PR TITLE
feat: Implement PWA as a share target for URLs

### DIFF
--- a/my-pwa/public/manifest.json
+++ b/my-pwa/public/manifest.json
@@ -18,6 +18,16 @@
       "sizes": "512x512"
     }
   ],
+  "share_target": {
+    "action": "shared-url-handler/",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  },
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#007bff",

--- a/my-pwa/src/App.js
+++ b/my-pwa/src/App.js
@@ -5,6 +5,7 @@ import { defuddle } from 'defuddle'; // Assuming defuddle is an ES module or has
 import './App.css';
 import UrlList from './UrlList';
 import ContentView from './ContentView';
+import SharedUrlReceiver from './SharedUrlReceiver'; // Import the new component
 
 // Configure localforage instance if needed
 localforage.config({
@@ -15,8 +16,37 @@ localforage.config({
 
 function App() {
   const [urls, setUrls] = useState([]); // {url: string, title?: string, simplifiedHtml?: string, status: 'unloaded' | 'loading' | 'loaded' | 'error', errorMessage?: string}
-  const [currentView, setCurrentView] = useState('list'); // 'list' | 'content'
+  const [currentView, setCurrentView] = useState('list'); // 'list' | 'content' | 'shared_content_view'
   const [contentToShow, setContentToShow] = useState(''); // HTML string or error message
+  const [sharedData, setSharedData] = useState(null); // {title, text, url}
+
+  // Effect for handling shared URL
+  useEffect(() => {
+    const publicUrl = process.env.PUBLIC_URL || '';
+    // Ensure sharePath has a trailing slash if your manifest action has it.
+    // The manifest action "shared-url-handler/" implies it will be a directory.
+    const sharePath = `${publicUrl}/shared-url-handler/`; 
+    
+    let currentPathname = window.location.pathname;
+    // Normalize currentPathname to ensure it also has a trailing slash if sharePath does
+    if (sharePath.endsWith('/') && !currentPathname.endsWith('/')) {
+      currentPathname += '/';
+    }
+
+    if (currentPathname === sharePath) {
+      const params = new URLSearchParams(window.location.search);
+      const url = params.get('url');
+      const title = params.get('title');
+      const text = params.get('text');
+
+      if (url) {
+        setSharedData({ url, title, text });
+        setCurrentView('shared_content_view');
+        // Optional: Clear search params from URL bar after processing
+        // window.history.replaceState({}, '', publicUrl || '/'); 
+      }
+    }
+  }, []); // Empty dependency array to run once on mount
 
   // Load URLs from localforage on initial render
   useEffect(() => {
@@ -122,6 +152,14 @@ function App() {
   const handleBackToList = () => {
     setCurrentView('list');
     setContentToShow('');
+    setSharedData(null); // Also clear shared data
+  };
+
+  const handleClearSharedView = () => {
+    setSharedData(null);
+    setCurrentView('list');
+    // Optional: Navigate to the base path if not already there
+    // window.history.pushState({}, '', process.env.PUBLIC_URL || '/');
   };
   
   // Simple input for adding new URLs - OPTIONAL but useful for testing
@@ -155,10 +193,14 @@ function App() {
           </div>
         )}
 
-        {currentView === 'list' ? (
+        {currentView === 'list' && (
           <UrlList urls={urls} onUrlClick={handleUrlClick} />
-        ) : (
+        )}
+        {currentView === 'content' && (
           <ContentView contentToShow={contentToShow} onBack={handleBackToList} />
+        )}
+        {currentView === 'shared_content_view' && sharedData && (
+          <SharedUrlReceiver data={sharedData} onClear={handleClearSharedView} />
         )}
       </main>
     </div>

--- a/my-pwa/src/SharedUrlReceiver.js
+++ b/my-pwa/src/SharedUrlReceiver.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+function SharedUrlReceiver({ data, onClear }) {
+  if (!data) {
+    // This case should ideally not be reached if App.js only renders it when data is present
+    return <p>No shared data available. Waiting for share...</p>;
+  }
+
+  return (
+    <div style={{ padding: '20px', border: '1px solid #eee', margin: '20px', backgroundColor: '#f9f9f9', borderRadius: '8px' }}>
+      <h2 style={{ marginTop: '0' }}>Shared Content Received:</h2>
+      {data.title && <p><strong>Title:</strong> {data.title}</p>}
+      {data.text && <p><strong>Text:</strong> {data.text}</p>}
+      {data.url && (
+        <p>
+          <strong>URL:</strong>{' '}
+          <a href={data.url} target="_blank" rel="noopener noreferrer">
+            {data.url}
+          </a>
+        </p>
+      )}
+      {!data.url && <p><em>No URL was shared.</em></p>}
+      <button 
+        onClick={onClear} 
+        style={{ 
+          marginTop: '15px', 
+          padding: '10px 15px', 
+          backgroundColor: '#007bff', 
+          color: 'white', 
+          border: 'none', 
+          borderRadius: '4px', 
+          cursor: 'pointer' 
+        }}
+      >
+        Clear Shared Content & View List
+      </button>
+    </div>
+  );
+}
+
+export default SharedUrlReceiver;


### PR DESCRIPTION
This commit enables the PWA to act as a share target on Android, allowing you to share URLs from other apps directly into this PWA.

Key changes:
- Updated `my-pwa/public/manifest.json`:
  - Added the `share_target` member, configured to accept URLs via GET request to the `shared-url-handler/` action path. Parameters include `title`, `text`, and `url`.

- Updated `my-pwa/src/App.js`:
  - Added logic to detect if the app was launched via the share target action path (`/pocket-reader/shared-url-handler/`).
  - Parses `title`, `text`, and `url` from query parameters.
  - Manages a new view state (`shared_content_view`) to display received shared data.

- Added `my-pwa/src/SharedUrlReceiver.js`:
  - A new React component responsible for rendering the shared `title`, `text`, and `url`.
  - Includes a button to clear the shared view and return to the main application list view.

The `homepage` setting in `package.json` ensures that the `action` path in `manifest.json` is correctly resolved relative to the PWA's base URL (`/pocket-reader/`). Manual testing on an Android device is recommended to confirm the share integration.