### PR TITLE
feat: Implement delete functionality for URL list items

### DIFF
--- a/my-pwa/src/App.js
+++ b/my-pwa/src/App.js
@@ -78,7 +78,11 @@ function App() {
     setUrls(prevUrls =>
       prevUrls.map(u => (u.url === targetUrl ? { ...u, ...newData } : u))
     );
-  }, []);
+  }, [setUrls]);
+
+  const handleDeleteUrl = useCallback((urlToDelete) => {
+    setUrls(prevUrls => prevUrls.filter(u => u.url !== urlToDelete));
+  }, [setUrls]);
 
   const handleUrlClick = useCallback(async (urlObject) => {
     if (urlObject.status === 'loaded' && urlObject.simplifiedHtml) {
@@ -135,7 +139,7 @@ function App() {
         // setCurrentView('content'); // Already in content view
       }
     }
-  }, [updateUrlData]);
+  }, [updateUrlData, setUrls]); // Added setUrls here just in case, though updateUrlData is the direct dependency
 
   const handleBackToList = () => {
     setCurrentView('list');
@@ -190,7 +194,7 @@ function App() {
           )}
 
           {currentView === 'list' && (
-            <UrlList urls={urls} onUrlClick={handleUrlClick} />
+            <UrlList urls={urls} onUrlClick={handleUrlClick} onDeleteUrl={handleDeleteUrl} />
           )}
           {currentView === 'content' && (
             <ContentView contentToShow={contentToShow} onBack={handleBackToList} />

--- a/my-pwa/src/App.test.js
+++ b/my-pwa/src/App.test.js
@@ -1,8 +1,121 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import App from './App';
+import { getAllUrls, saveUrls, initDB } from './indexedDBUtils';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Mock the indexedDBUtils module
+jest.mock('./indexedDBUtils');
+
+describe('App component', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    getAllUrls.mockReset();
+    saveUrls.mockReset();
+    initDB.mockReset();
+
+    // Default mock implementations
+    initDB.mockResolvedValue(undefined); // Simulate successful DB initialization
+    saveUrls.mockResolvedValue(undefined); // Simulate successful save
+  });
+
+  test('renders app title and can add and delete a URL', async () => {
+    const initialUrls = [
+      { url: 'https://example.com/page1', title: 'Page 1', status: 'loaded', simplifiedHtml: '<p>Page 1</p>' },
+      { url: 'https://example.com/page2', title: 'Page 2', status: 'unloaded' },
+    ];
+    getAllUrls.mockResolvedValue([...initialUrls]); // Return a copy
+
+    render(<App />);
+
+    // Check for App Bar title
+    expect(screen.getByText(/URL Viewer PWA/i)).toBeInTheDocument();
+
+    // Wait for initial URLs to be loaded and displayed
+    // Ensure items are rendered by looking for their primary text (title or URL)
+    await waitFor(async () => { // Make inner function async for findBy
+      expect(await screen.findByText(initialUrls[0].title)).toBeInTheDocument();
+      expect(await screen.findByText(initialUrls[1].url)).toBeInTheDocument(); // Page 2 has no title initially
+    });
+
+    // --- Test Deletion ---
+    // Find the list item for the first URL (Page 1)
+    // It's an <li> rendered by ListItemButton, but MUI gives it role="button".
+    const listItemPage1 = screen.getByRole('button', { name: new RegExp(initialUrls[0].title, 'i') });
+    expect(listItemPage1).toBeInTheDocument();
+
+
+    // Find the delete button within that list item
+    const deleteButtonPage1 = within(listItemPage1).getByRole('button', { name: /delete url/i });
+    fireEvent.click(deleteButtonPage1);
+
+    // Wait for the URL to be removed
+    await waitFor(() => {
+      expect(screen.queryByText(initialUrls[0].title)).not.toBeInTheDocument();
+    });
+
+    // Ensure the second URL is still present
+    expect(screen.getByText(initialUrls[1].url)).toBeInTheDocument();
+
+    // Check if saveUrls was called after deletion (it should be, due to useEffect in App.js)
+    // The state updates, triggering the useEffect hook that calls saveUrls.
+    // The argument to saveUrls should be the list of URLs *after* deletion.
+    await waitFor(() => {
+      expect(saveUrls).toHaveBeenCalledTimes(2); 
+
+      // Check the arguments of the LAST call to saveUrls
+      expect(saveUrls).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ url: initialUrls[1].url }), // Should contain Page 2
+        ])
+      );
+      expect(saveUrls).toHaveBeenLastCalledWith(
+        expect.not.arrayContaining([
+          expect.objectContaining({ url: initialUrls[0].url }), // Should NOT contain Page 1
+        ])
+      );
+    });
+
+    // --- Test Addition (Optional but good to keep a comprehensive test) ---
+    const newUrl = 'https://example.com/newpage';
+    const urlInput = screen.getByLabelText(/Enter URL to add/i);
+    const addButton = screen.getByRole('button', { name: /Add URL/i });
+
+    fireEvent.change(urlInput, { target: { value: newUrl } });
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(newUrl)).toBeInTheDocument();
+    });
+    
+    // Verify saveUrls was called again after addition
+    await waitFor(() => {
+        expect(saveUrls).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ url: initialUrls[1].url }),
+                expect.objectContaining({ url: newUrl, status: 'unloaded' })
+            ])
+        );
+    });
+
+  });
+
+  // Test for initial empty state or error loading from DB can be added here
+  test('renders correctly when no URLs are in IndexedDB', async () => {
+    getAllUrls.mockResolvedValue([]); // No URLs stored
+    render(<App />);
+    // Check that default URLs are added (as per App.js logic)
+    await waitFor(() => {
+      expect(screen.getByText('https://www.google.com')).toBeInTheDocument();
+      expect(screen.getByText('https://www.wikipedia.org')).toBeInTheDocument();
+    });
+    // And that these defaults are then saved
+    await waitFor(() => {
+        expect(saveUrls).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({ url: 'https://www.google.com' }),
+                expect.objectContaining({ url: 'https://www.wikipedia.org' })
+            ])
+        );
+    });
+  });
+
 });

--- a/my-pwa/src/UrlItem.js
+++ b/my-pwa/src/UrlItem.js
@@ -5,9 +5,12 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import IconButton from '@mui/material/IconButton';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 // import LinkIcon from '@mui/icons-material/Link'; // Example, if needed for 'loaded' state
 
-const UrlItem = ({ urlObject, onUrlClick }) => {
+const UrlItem = ({ urlObject, onUrlClick, onDeleteUrl }) => {
   const handleClick = () => {
     onUrlClick(urlObject);
   };
@@ -54,7 +57,7 @@ const UrlItem = ({ urlObject, onUrlClick }) => {
 
 
   return (
-    <ListItemButton onClick={handleClick} divider>
+    <ListItemButton component="li" onClick={handleClick} divider>
       {(urlObject.status === 'loading' || urlObject.status === 'error') && (
         <ListItemIcon sx={{minWidth: '40px'}}> {/* Adjust minWidth if icons look too spaced out */}
           {urlObject.status === 'loading' && <CircularProgress size={24} />}
@@ -69,6 +72,18 @@ const UrlItem = ({ urlObject, onUrlClick }) => {
         primary={primaryText}
         secondary={secondaryTextElements.length > 0 ? <React.Fragment>{secondaryTextElements}</React.Fragment> : null}
       />
+      <ListItemSecondaryAction>
+        <IconButton
+          edge="end"
+          aria-label="delete url"
+          onClick={(event) => {
+            event.stopPropagation(); // Prevent ListItemButton click
+            onDeleteUrl(urlObject.url);
+          }}
+        >
+          <DeleteIcon />
+        </IconButton>
+      </ListItemSecondaryAction>
     </ListItemButton>
   );
 };

--- a/my-pwa/src/UrlItem.test.js
+++ b/my-pwa/src/UrlItem.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UrlItem from './UrlItem';
+
+describe('UrlItem component', () => {
+  const mockUrlObject = {
+    url: 'https://example.com',
+    title: 'Example Site',
+    status: 'loaded', // or 'unloaded', 'loading', 'error'
+    simplifiedHtml: '<p>Example HTML</p>',
+    errorMessage: undefined,
+  };
+
+  test('renders URL information correctly', () => {
+    render(<UrlItem urlObject={mockUrlObject} onUrlClick={jest.fn()} onDeleteUrl={jest.fn()} />);
+    
+    // Check if title is rendered (since status is 'loaded' and title exists)
+    expect(screen.getByText(mockUrlObject.title)).toBeInTheDocument();
+    // Check if URL is rendered as secondary text
+    expect(screen.getByText(mockUrlObject.url)).toBeInTheDocument(); 
+  });
+
+  test('calls onUrlClick when the item is clicked', () => {
+    const mockOnUrlClick = jest.fn();
+    render(<UrlItem urlObject={mockUrlObject} onUrlClick={mockOnUrlClick} onDeleteUrl={jest.fn()} />);
+    
+    // Click the main body of the list item
+    // The primary text (title) is a good target if the whole item is clickable
+    fireEvent.click(screen.getByText(mockUrlObject.title));
+    expect(mockOnUrlClick).toHaveBeenCalledTimes(1);
+    expect(mockOnUrlClick).toHaveBeenCalledWith(mockUrlObject);
+  });
+
+  test('calls onDeleteUrl with the correct URL when delete button is clicked', () => {
+    const mockOnDeleteUrl = jest.fn();
+    render(<UrlItem urlObject={mockUrlObject} onUrlClick={jest.fn()} onDeleteUrl={mockOnDeleteUrl} />);
+    
+    const deleteButton = screen.getByRole('button', { name: /delete url/i });
+    fireEvent.click(deleteButton);
+    
+    expect(mockOnDeleteUrl).toHaveBeenCalledTimes(1);
+    expect(mockOnDeleteUrl).toHaveBeenCalledWith(mockUrlObject.url);
+  });
+
+  test('clicking delete button does not trigger onUrlClick', () => {
+    const mockOnUrlClick = jest.fn();
+    const mockOnDeleteUrl = jest.fn();
+    render(<UrlItem urlObject={mockUrlObject} onUrlClick={mockOnUrlClick} onDeleteUrl={mockOnDeleteUrl} />);
+    
+    const deleteButton = screen.getByRole('button', { name: /delete url/i });
+    fireEvent.click(deleteButton);
+    
+    expect(mockOnDeleteUrl).toHaveBeenCalledTimes(1);
+    expect(mockOnUrlClick).not.toHaveBeenCalled();
+  });
+
+  // Test for different statuses (loading, error, unloaded) can be added here
+  test('displays loading indicator when status is "loading"', () => {
+    const loadingUrlObject = { ...mockUrlObject, status: 'loading', title: undefined };
+    render(<UrlItem urlObject={loadingUrlObject} onUrlClick={jest.fn()} onDeleteUrl={jest.fn()} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    // URL should be primary text if no title and loading
+    expect(screen.getByText(loadingUrlObject.url)).toBeInTheDocument();
+  });
+
+  test('displays error icon and message when status is "error"', () => {
+    const errorUrlObject = { 
+      ...mockUrlObject, 
+      status: 'error', 
+      errorMessage: 'Failed to load', 
+      title: 'Error Page' // Title might exist even if there was an error
+    };
+    render(<UrlItem urlObject={errorUrlObject} onUrlClick={jest.fn()} onDeleteUrl={jest.fn()} />);
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument(); // MUI icons often have test IDs like this, or check role
+    expect(screen.getByText(`Error: ${errorUrlObject.errorMessage}`)).toBeInTheDocument();
+    // Title should still be shown if available
+     expect(screen.getByText(errorUrlObject.title)).toBeInTheDocument();
+  });
+
+});

--- a/my-pwa/src/UrlList.js
+++ b/my-pwa/src/UrlList.js
@@ -2,11 +2,11 @@ import React from 'react';
 import UrlItem from './UrlItem';
 import List from '@mui/material/List';
 
-const UrlList = ({ urls, onUrlClick }) => {
+const UrlList = ({ urls, onUrlClick, onDeleteUrl }) => {
   return (
     <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
       {urls.map((urlObj, index) => ( // Using index as key is not ideal if list can be reordered, but ok for now
-        <UrlItem key={urlObj.url || index} urlObject={urlObj} onUrlClick={onUrlClick} />
+        <UrlItem key={urlObj.url || index} urlObject={urlObj} onUrlClick={onUrlClick} onDeleteUrl={onDeleteUrl} />
       ))}
     </List>
   );

--- a/my-pwa/src/indexedDBUtils.js
+++ b/my-pwa/src/indexedDBUtils.js
@@ -203,6 +203,8 @@ async function handleSharedUrl(sharedUrl, sharedTitle, sharedText) {
 
 // It's good practice to also handle potential errors from initDB itself,
 // though the individual functions already await it.
-initDB().catch(error => {
-  console.error("Failed to initialize IndexedDB on module load:", error);
-});
+if (process.env.NODE_ENV !== 'test') {
+  initDB().catch(error => {
+    console.error("Failed to initialize IndexedDB on module load:", error);
+  });
+}


### PR DESCRIPTION
This commit introduces the ability for you to remove URLs from your list.

Key changes:
- Added a `handleDeleteUrl` function in `App.js` to manage the removal of URLs from the application state and persist changes to IndexedDB.
- Passed the `handleDeleteUrl` function as a prop down to `UrlItem` via `UrlList`.
- Added a trash icon `IconButton` to each `UrlItem`. Clicking this button now triggers the `handleDeleteUrl` function for the respective URL.
- Ensured that clicking the delete button does not also trigger the main click action for the list item by using `event.stopPropagation()`.
- Added comprehensive unit tests for `App.js` and `UrlItem.js` (new file) to cover the new delete functionality, including verification of state changes, DOM updates, and correct mock function calls.
- Fixed an issue where `handleDeleteUrl` was not correctly passed as a prop in `App.js`.
- Improved list item semantics in `UrlItem.js` by ensuring `ListItemButton` renders as an `<li>` when appropriate.
- Prevented `indexedDBUtils.js` from attempting to initialize the DB during test runs.