### PR TITLE
fix: Remove unnecessary setUrls from useCallback dependencies

### DIFF
--- a/my-pwa/src/App.js
+++ b/my-pwa/src/App.js
@@ -78,11 +78,11 @@ function App() {
     setUrls(prevUrls =>
       prevUrls.map(u => (u.url === targetUrl ? { ...u, ...newData } : u))
     );
-  }, [setUrls]);
+  }, []);
 
   const handleDeleteUrl = useCallback((urlToDelete) => {
     setUrls(prevUrls => prevUrls.filter(u => u.url !== urlToDelete));
-  }, [setUrls]);
+  }, []);
 
   const handleUrlClick = useCallback(async (urlObject) => {
     if (urlObject.status === 'loaded' && urlObject.simplifiedHtml) {
@@ -139,7 +139,7 @@ function App() {
         // setCurrentView('content'); // Already in content view
       }
     }
-  }, [updateUrlData, setUrls]); // Added setUrls here just in case, though updateUrlData is the direct dependency
+  }, [updateUrlData]);
 
   const handleBackToList = () => {
     setCurrentView('list');

--- a/my-pwa/src/App.test.js
+++ b/my-pwa/src/App.test.js
@@ -60,7 +60,7 @@ describe('App component', () => {
     // The state updates, triggering the useEffect hook that calls saveUrls.
     // The argument to saveUrls should be the list of URLs *after* deletion.
     await waitFor(() => {
-      expect(saveUrls).toHaveBeenCalledTimes(2); 
+      expect(saveUrls).toHaveBeenCalledTimes(2);
 
       // Check the arguments of the LAST call to saveUrls
       expect(saveUrls).toHaveBeenLastCalledWith(
@@ -86,7 +86,7 @@ describe('App component', () => {
     await waitFor(() => {
       expect(screen.getByText(newUrl)).toBeInTheDocument();
     });
-    
+
     // Verify saveUrls was called again after addition
     await waitFor(() => {
         expect(saveUrls).toHaveBeenCalledWith(

--- a/my-pwa/src/UrlItem.js
+++ b/my-pwa/src/UrlItem.js
@@ -59,10 +59,10 @@ const UrlItem = ({ urlObject, onUrlClick, onDeleteUrl }) => {
 
   return (
     <ListItem component="li" divider disableGutters sx={{ position: 'relative' }}>
-      <ListItemButton 
-        onClick={handleClick} 
+      <ListItemButton
+        onClick={handleClick}
         // sx={{ flexGrow: 1 }} // flexGrow might not be needed if pr is set correctly
-        sx={{ 
+        sx={{
           pr: 9, // Padding right for the secondary action
           // flexGrow: 1, // Optional: see if needed with padding
         }}
@@ -74,7 +74,7 @@ const UrlItem = ({ urlObject, onUrlClick, onDeleteUrl }) => {
           </ListItemIcon>
         )}
         {/* Optional: Add placeholder for alignment if needed, though flexGrow on ListItemButton might handle this better
-        {urlObject.status !== 'loading' && urlObject.status !== 'error' && <ListItemIcon sx={{minWidth: '40px', visibility: 'hidden'}} />} 
+        {urlObject.status !== 'loading' && urlObject.status !== 'error' && <ListItemIcon sx={{minWidth: '40px', visibility: 'hidden'}} />}
         */}
         <ListItemText
           primary={primaryText}

--- a/my-pwa/src/UrlItem.test.js
+++ b/my-pwa/src/UrlItem.test.js
@@ -14,17 +14,17 @@ describe('UrlItem component', () => {
 
   test('renders URL information correctly', () => {
     render(<UrlItem urlObject={mockUrlObject} onUrlClick={jest.fn()} onDeleteUrl={jest.fn()} />);
-    
+
     // Check if title is rendered (since status is 'loaded' and title exists)
     expect(screen.getByText(mockUrlObject.title)).toBeInTheDocument();
     // Check if URL is rendered as secondary text
-    expect(screen.getByText(mockUrlObject.url)).toBeInTheDocument(); 
+    expect(screen.getByText(mockUrlObject.url)).toBeInTheDocument();
   });
 
   test('calls onUrlClick when the item is clicked', () => {
     const mockOnUrlClick = jest.fn();
     render(<UrlItem urlObject={mockUrlObject} onUrlClick={mockOnUrlClick} onDeleteUrl={jest.fn()} />);
-    
+
     // Click the main body of the list item
     // The primary text (title) is a good target if the whole item is clickable
     fireEvent.click(screen.getByText(mockUrlObject.title));
@@ -35,10 +35,10 @@ describe('UrlItem component', () => {
   test('calls onDeleteUrl with the correct URL when delete button is clicked', () => {
     const mockOnDeleteUrl = jest.fn();
     render(<UrlItem urlObject={mockUrlObject} onUrlClick={jest.fn()} onDeleteUrl={mockOnDeleteUrl} />);
-    
+
     const deleteButton = screen.getByRole('button', { name: /delete url/i });
     fireEvent.click(deleteButton);
-    
+
     expect(mockOnDeleteUrl).toHaveBeenCalledTimes(1);
     expect(mockOnDeleteUrl).toHaveBeenCalledWith(mockUrlObject.url);
   });
@@ -47,10 +47,10 @@ describe('UrlItem component', () => {
     const mockOnUrlClick = jest.fn();
     const mockOnDeleteUrl = jest.fn();
     render(<UrlItem urlObject={mockUrlObject} onUrlClick={mockOnUrlClick} onDeleteUrl={mockOnDeleteUrl} />);
-    
+
     const deleteButton = screen.getByRole('button', { name: /delete url/i });
     fireEvent.click(deleteButton);
-    
+
     expect(mockOnDeleteUrl).toHaveBeenCalledTimes(1);
     expect(mockOnUrlClick).not.toHaveBeenCalled();
   });
@@ -65,10 +65,10 @@ describe('UrlItem component', () => {
   });
 
   test('displays error icon and message when status is "error"', () => {
-    const errorUrlObject = { 
-      ...mockUrlObject, 
-      status: 'error', 
-      errorMessage: 'Failed to load', 
+    const errorUrlObject = {
+      ...mockUrlObject,
+      status: 'error',
+      errorMessage: 'Failed to load',
       title: 'Error Page' // Title might exist even if there was an error
     };
     render(<UrlItem urlObject={errorUrlObject} onUrlClick={jest.fn()} onDeleteUrl={jest.fn()} />);


### PR DESCRIPTION
This commit resolves a react-hooks/exhaustive-deps linting error by removing `setUrls` from the dependency arrays of `useCallback` hooks in App.js.

Setter functions obtained from `useState` (like `setUrls`) are guaranteed by React to have a stable identity and do not need to be included in dependency arrays for hooks like `useCallback`.

The following hooks were updated:
- `updateUrlData`: dependency array changed from `[setUrls]` to `[]`.
- `handleDeleteUrl`: dependency array changed from `[setUrls]` to `[]`.
- `handleUrlClick`: dependency array changed from `[updateUrlData, setUrls]` to `[updateUrlData]`.

This change ensures compliance with the exhaustive-deps rule and prevents potential build failures related to this linting error. All tests continue to pass.